### PR TITLE
Update following horizontalpodautoscaler deprecation guide

### DIFF
--- a/charts/unleash/templates/hpa.yaml
+++ b/charts/unleash/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "unleash.fullname" . }}


### PR DESCRIPTION
Update following horizontalpodautoscaler [deprecation guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v125).

For more context, see this [thread](https://blablacar.slack.com/archives/CL3CXAYET/p1697617779277819).